### PR TITLE
Remove E_STRICT from bootstrap on modern PHP

### DIFF
--- a/templates/3.3/dev/koharness_bootstrap.php
+++ b/templates/3.3/dev/koharness_bootstrap.php
@@ -19,7 +19,13 @@ define('SYSPATH', '$syspath');
 define('DOCROOT', '$docroot');
 define('KOHARNESS_SRC', '$cwd/vendor/kohana/koharness/');
 define('EXT', '.php');
-error_reporting(E_ALL | E_STRICT);
+if (PHP_VERSION_ID < 50400) {
+  // Legacy behaviour (assumed unused) for consumers on 5.3.x
+  error_reporting(E_ALL | E_STRICT);
+} else {
+  // For all versions >= 5.4.0, E_ALL is functionally identical to E_ALL | E_STRICT.
+  error_reporting(E_ALL)
+}
 define('KOHANA_START_TIME', microtime(TRUE));
 define('KOHANA_START_MEMORY', memory_get_usage());
 


### PR DESCRIPTION
* Below PHP 5.4, E_ALL did not include E_STRICT. Include it (for BC) as this package nominally still supports 5.3.x, not that we expect anyone to be using it.
* From 5.4 - 7.4, E_ALL already includes the E_STRICT   bit (e.g. is identical to above) and may catch errors.
* From 8.0 - 8.3, E_ALL includes E_STRICT but cannot in   practice catch anything as nothing can emit an E_STRICT in these PHP versions.
* From 8.4 up, E_ALL does not include E_STRICT and E_STRICT is deprecated (but as above it was already a no-op for the whole 8.x series).

Therefore for all versions >= 5.4.0,  E_ALL gives the same behaviour as E_ALL | E_STRICT.